### PR TITLE
Add Cloudflare Tunnel container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Cloudflare config
+src/docker/.env

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ I suggest buying your domain name from Cloudflare for simplicity, but I have dom
 1. Select Cloudflared.
 1. Name your tunnel something simple and relevant.
 1. Copy the connector command and get the token.
-1. Save the token to your `.env` file
-    - `echo "CLOUDFLARED_TOKEN=[token]" >> .env`
+1. Save the token to your `.env` file 
+    - `TUNNEL_TOKEN=<token>`
 
 # React + TypeScript + Vite
 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,29 @@ Host a static site from your own computer with no hassle.
 
 # Development
 
-## App
+## Server App
 
-first, install NPM.
+First, install NPM.
 
-then do `npm run dev`. 
+Then do `npm run dev`. 
 
-## Docker
+## Docker Development / Manual Hosting (auto setup WIP)
 
 First, install Docker Desktop at https://docs.docker.com/get-started/get-docker/.
 
 Navigate to the `src/docker` directory. From here, run one of the following commands:
 1.  `docker-compose --profile dev up`.  
 This will run the website locally and automatically reload any changes. you can access it from your browser at `localhost:4000`.
-1.   `docker-compose --profile production up` This will build the static Jekyll app, and mount the Nginx server to the `_site/` directory containing the bundled static files. 
+1.   `docker-compose --profile prod up` This will build the static Jekyll app, and mount the Nginx server to the `_site/` directory containing the bundled static files. 
+I recommend saving these commands to an alias because of their unfortunate verbosity.
 
+### Cloudflare
+To actually publish your site to the public facing web, we use a secure Cloudflare Tunnel.
+The tunnel connects an isolated port on your computer to Cloudflare's network. 
+Of course, to be on the web, you must buy and set up your domain credentials with both Cloudflare and whoever you bought it from. 
+I suggest buying your domain name from Cloudflare for simplicity, but I have domains on Namecheap and GoDaddy as well.
+- [Tunnel Dashboard](https://one.dash.cloudflare.com/ad71e39cf0ae1bd7f311f61bb5f86ceb/networks/tunnels)
+- [Tunnel Docs](https://one.dash.cloudflare.com/ad71e39cf0ae1bd7f311f61bb5f86ceb/networks/tunnels)
 
 
 # React + TypeScript + Vite

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ I suggest buying your domain name from Cloudflare for simplicity, but I have dom
 - [Tunnel Dashboard](https://one.dash.cloudflare.com/ad71e39cf0ae1bd7f311f61bb5f86ceb/networks/tunnels)
 - [Tunnel Docs](https://one.dash.cloudflare.com/ad71e39cf0ae1bd7f311f61bb5f86ceb/networks/tunnels)
 
+1. Click on the Tunnel Dashboard above.
+1. Click the "Create a tunnel" button.
+1. Select Cloudflared.
+1. Name your tunnel something simple and relevant.
+1. Copy the connector command and get the token.
+1. Save the token to your `.env` file
+    - `echo "CLOUDFLARED_TOKEN=[token]" >> .env`
 
 # React + TypeScript + Vite
 

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     command: "jekyll build -w"
     profiles:
       - prod
+    restart: unless-stopped
   # Host the files of the site on port 8089
   nginx:
     image: nginx:latest
@@ -21,6 +22,7 @@ services:
       - ./jekyll/_site/:/usr/share/nginx/html
     profiles:
       - prod
+    restart: unless-stopped
   # Hook nginx exposed port onto the web
   cloudflared:
     image: cloudflare/cloudflared:latest

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+  # Build and hot reload (-w) static Markdown files in the .posts/ directory
   jekyll-prod:
     build:
       context: .
@@ -8,7 +9,8 @@ services:
       - "4000:4000"
     command: "jekyll build -w"
     profiles:
-      - production
+      - prod
+  # Host the files of the site on port 8089
   nginx:
     image: nginx:latest
     depends_on:
@@ -18,7 +20,19 @@ services:
     volumes:
       - ./jekyll/_site/:/usr/share/nginx/html
     profiles:
-      - production
+      - prod
+  # Hook nginx exposed port onto the web
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    depends_on:
+      - nginx
+    profiles:
+      - prod
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN}
+    env_file:
+      - .env
+    network_mode: "host" # Ensures it can connect to services on localhost
   jekyll-dev:
     build:
       context: .

--- a/src/electron/api.ts
+++ b/src/electron/api.ts
@@ -54,7 +54,7 @@ ipcMain.handle("kill-dev-server", (_event: IpcMainInvokeEvent) => {
 
 ipcMain.handle("run-prod-server", (_event: IpcMainInvokeEvent) => {
   exec(
-    `docker compose -f src/docker/docker-compose.yml --profile production up --build -d`,
+    `docker compose -f src/docker/docker-compose.yml --profile prod up --build -d`,
     (error) => {
       if (error) {
         console.error("Error starting Docker Compose:", error.message);
@@ -67,7 +67,7 @@ ipcMain.handle("run-prod-server", (_event: IpcMainInvokeEvent) => {
 
 ipcMain.handle("kill-prod-server", (_event: IpcMainInvokeEvent) => {
   exec(
-    `docker compose -f src/docker/docker-compose.yml --profile production down`,
+    `docker compose -f src/docker/docker-compose.yml --profile prod down`,
     (error) => {
       if (error) {
         console.error("Error stopping docker:", error.message);

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,6 +1,6 @@
 import { HashRouter, Route, Routes } from "react-router-dom";
 
-import NavbarLayout from "./components/Navbar/NavbarLayout";
+import NavbarLayout from "./components/navbar/NavbarLayout";
 import AboutContainer from "./components/About/AboutContainer";
 import HomeContainer from "./components/Home/HomeContainer";
 import DocsContainer from "./components/Docs/DocsContainer";


### PR DESCRIPTION
Part of Issue #10. Eventually, users should only have to paste in their Cloudflare tunnel token into the Desktop app. Anyway, this adds a new container which handles connecting to the web! All you need it that token in a `.env` file in the `src/docker` directory.